### PR TITLE
Updated the "Thank you to Anton", and the IAM policy document

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -200,12 +200,8 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 
-##
-## The alarm metric names, descriptions, and filters from this repository were used
-## https://github.com/TeliaSoneraNorge/telia-terraform-modules/tree/master/cloudtrail-forwarder
-## With many thanks to Anton https://github.com/antonbabenko for pointing it out and saving
-## me a lot of time scouring reference documents and describing alarms!
-##
+>  The alarm metric names, descriptions, and filters [from this repository were used](https://github.com/TeliaSoneraNorge/telia-terraform-modules/tree/master/cloudtrail-forwarder).
+>  With many thanks to [Anton](https://github.com/antonbabenko) for pointing it out and saving me a lot of time scouring reference documents and describing alarms!
 
 MIT License
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ For detailed usage which includes setting up cloudtrail, cloudwatch logs, roles,
 
 ## Dashboard Created
 Two CloudWatch Dashboards can be created as well, and will be automatically created by default.
-[![CloudWatch Dashboard](./docs/screen1.png)]
+![CloudWatch Dashboard](./docs/screen1.png)
 
 ### From LICENSE
 >  The alarm metric names, descriptions, and filters from this repository were used

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -15,5 +15,6 @@
 
 ## Dashboard Created
 Two CloudWatch Dashboards can be created as well, and will be automatically created by default.
-[![CloudWatch Dashboard](./docs/screen1.png)]
+
+![CloudWatch Dashboard](./docs/screen1.png)
 

--- a/docs/thanks.md
+++ b/docs/thanks.md
@@ -1,6 +1,5 @@
 ### From LICENSE
->  The alarm metric names, descriptions, and filters from this repository were used
->  https://github.com/TeliaSoneraNorge/telia-terraform-modules/tree/master/cloudtrail-forwarder
->  With many thanks to Anton https://github.com/antonbabenko for pointing it out and saving
->  me a lot of time scouring reference documents and describing alarms!
+>  The alarm metric names, descriptions, and filters [from this repository were used](https://github.com/TeliaSoneraNorge/telia-terraform-modules/tree/master/cloudtrail-forwarder).
+>  With many thanks to [Anton Babenko](https://github.com/antonbabenko) for pointing it out and saving me a lot of time scouring reference documents and describing alarms!
+
 

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
     ]
 
     effect    = "Allow"
-    resources = ["${aws_sns_topic.default.arn}"]
+    resources = ["${local.sns_topic_arn}"]
 
     principals {
       type        = "AWS"
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
   statement {
     sid       = "Allow ${local.alert_for} CloudwatchEvents"
     actions   = ["sns:Publish"]
-    resources = ["${aws_sns_topic.default.arn}"]
+    resources = ["${local.sns_topic_arn}"]
 
     principals {
       type        = "Service"


### PR DESCRIPTION
## What:
- Updated the references to Anton
- Updated the IAM policy document to use `local.sns_topic_arn` as the resource.

## Why
- Credit due
- So that when a user provided sns topic is passed in as a variable, the policy document is still correct.