### PR TITLE
fixing permissions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,8 +53,14 @@ data "aws_iam_policy_document" "sns_topic_policy" {
     resources = ["${local.sns_topic_arn}"]
 
     principals {
-      type        = "Service"
-      identifiers = ["events.amazonaws.com"]
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = ["${aws_cloudwatch_metric_alarm.default.*.arn}"]
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -53,7 +53,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
     resources = ["${local.sns_topic_arn}"]
 
     principals {
-      type        = "*"
+      type        = "AWS"
       identifiers = ["*"]
     }
 


### PR DESCRIPTION
This module did not work for me w/out the following modification. I had to contact AWS Support, who told me that these alerts do *not* originate from `events.amazonaws.com`.