### PR TITLE
Update Terraform syntax to v0.12 and fix variable errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
  [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-cloudtrail-cloudwatch-alarms.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-aws-cloudtrail-cloudwatch-alarms) [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-aws-cloudtrail-cloudwatch-alarms.svg)](https://github.com/cloudposse/terraform-aws-cloudtrail-cloudwatch-alarms/releases) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
 
 
-Terraform module for creating alarms for tracking important changes and occurances from cloudtrail.
+Terraform module for creating alarms for tracking important changes and occurrences from CloudTrail.
 
 This module creates a set of filter metrics and alarms based on the security best practices covered in the [AWS CIS Foundations Benchmark](https://d0.awsstatic.com/whitepapers/compliance/AWS_CIS_Foundations_Benchmark.pdf) guide.
 
@@ -37,7 +37,7 @@ module "cloudtrail_api_alarms" {
   log_group_name = "${aws_cloudwatch_log_group.default.name}"
 }
 ```
-For detailed usage which includes setting up cloudtrail, cloudwatch logs, roles, policies, and the s3 bucket - as well as using this module see the [example directory](./examples/simple)
+For detailed usage which includes setting up CloudTrail, CloudWatch logs, roles, policies, and the s3 bucket - as well as using this module see the [example directory](./examples/simple)
 
 
 
@@ -54,11 +54,11 @@ Here's a complete [example](examples/simple/main.tf) of using this `terraform-aw
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | add_sns_policy | Attach a policy that allows the notifications through to the SNS topic endpoint | bool | `false` | no |
-| additional_endpoint_arns | Any alert endpoints, such as autoscaling, or app scaling endpoint arns that will respond to an alert | list(string) | `<list>` | no |
+| additional_endpoint_arns | Any alert endpoints, such as autoscaling, or app scaling endpoint ARNs that will respond to an alert | list(string) | `<list>` | no |
 | create_dashboard | When true a dashboard that displays the statistics as a line graph will be created in CloudWatch | bool | `true` | no |
-| log_group_name | The cloudtrail cloudwatch log group name | string | - | yes |
+| log_group_name | The CloudTrail CloudWatch log group name | string | - | yes |
 | metric_namespace | A namespace for grouping all of the metrics together | string | `CISBenchmark` | no |
-| region | The region that should be monitored for unauthorised AWS API Access. Current region used if none provied. | string | `null` | no |
+| region | The region that should be monitored for unauthorized AWS API Access. Current region used if none is provided. | string | `null` | no |
 | sns_topic_arn | An SNS topic ARN that has already been created. Its policy must already allow access from CloudWatch Alarms, or set `add_sns_policy` to `true` | string | `null` | no |
 
 ## Outputs
@@ -81,7 +81,7 @@ Here's a complete [example](examples/simple/main.tf) of using this `terraform-aw
 |  `VpcEventCount`                   |  Alarms when an API call is made to create, update or delete a VPC, VPC peering connection or VPC connection to classic.  |
 |  `EC2InstanceEventCount`           |  Alarms when an API call is made to create, terminate, start, stop or reboot an EC2 instance.  |
 |  `EC2LargeInstanceEventCount`      |  Alarms when an API call is made to create, terminate, start, stop or reboot a 4x-large or greater EC2 instance.  |
-|  `CloudTrailEventCount`            |  Alarms when an API call is made to create, update or delete a .cloudtrail. trail, or to start or stop logging to a trail.  |
+|  `CloudTrailEventCount`            |  Alarms when an API call is made to create, update or delete a CloudTrail trail, or to start or stop logging to a trail.  |
 |  `ConsoleSignInFailureCount`       |  Alarms when an unauthenticated API call is made to sign into the console.  |
 |  `IAMPolicyEventCount`             |  Alarms when an API call is made to change an IAM policy.   |
 |  `ConsoleSignInWithoutMfaCount`    |  Alarms when a user logs into the console without MFA.   |
@@ -90,9 +90,9 @@ Here's a complete [example](examples/simple/main.tf) of using this `terraform-aw
 |  `AWSConfigChangeCount`            |  Alarms when AWS Config changes.   |
 |  `RouteTableChangesCount`          |  Alarms when route table changes are detected.   |
 
-## Dashboard Created
+## Dashboards Created
 
-Two CloudWatch Dashboards can be created as well, and will be automatically created by default.
+By default two CloudWatch Dashboards will be automatically created.
 
 ![CloudWatch Dashboard](docs/screen1.png)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This module creates a set of filter metrics and alarms based on the security bes
 
 ---
 
-This project is part of our comprehensive ["SweetOps"](https://docs.cloudposse.com) approach towards DevOps. 
+This project is part of our comprehensive ["SweetOps"](https://docs.cloudposse.com) approach towards DevOps.
 
 
 It's 100% Open Source and licensed under the [APACHE2](LICENSE).
@@ -53,13 +53,13 @@ Here's a complete [example](examples/simple/main.tf) of using this `terraform-aw
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| add_sns_policy | Attach a policy that allows the notifications through to the SNS topic endpoint | string | `false` | no |
-| additional_endpoint_arns | Any alert endpoints, such as autoscaling, or app scaling endpoint arns that will respond to an alert | list | `<list>` | no |
-| create_dashboard | When true a dashboard that displays the statistics as a line graph will be created in CloudWatch | string | `true` | no |
+| add_sns_policy | Attach a policy that allows the notifications through to the SNS topic endpoint | bool | `false` | no |
+| additional_endpoint_arns | Any alert endpoints, such as autoscaling, or app scaling endpoint arns that will respond to an alert | list(string) | `<list>` | no |
+| create_dashboard | When true a dashboard that displays the statistics as a line graph will be created in CloudWatch | bool | `true` | no |
 | log_group_name | The cloudtrail cloudwatch log group name | string | - | yes |
 | metric_namespace | A namespace for grouping all of the metrics together | string | `CISBenchmark` | no |
-| region | The region that should be monitored for unauthorised AWS API Access. Current region used if none provied. | string | `` | no |
-| sns_topic_arn | An SNS topic ARN that has already been created. Its policy must already allow access from CloudWatch Alarms, or set `add_sns_policy` to `true` | string | `` | no |
+| region | The region that should be monitored for unauthorised AWS API Access. Current region used if none provied. | string | `null` | no |
+| sns_topic_arn | An SNS topic ARN that has already been created. Its policy must already allow access from CloudWatch Alarms, or set `add_sns_policy` to `true` | string | `null` | no |
 
 ## Outputs
 
@@ -132,9 +132,9 @@ File a GitHub [issue](https://github.com/cloudposse/terraform-aws-cloudtrail-clo
 
 ## Commercial Support
 
-Work directly with our team of DevOps experts via email, slack, and video conferencing. 
+Work directly with our team of DevOps experts via email, slack, and video conferencing.
 
-We provide [*commercial support*][commercial_support] for all of our [Open Source][github] projects. As a *Dedicated Support* customer, you have access to our team of subject matter experts at a fraction of the cost of a full-time engineer. 
+We provide [*commercial support*][commercial_support] for all of our [Open Source][github] projects. As a *Dedicated Support* customer, you have access to our team of subject matter experts at a fraction of the cost of a full-time engineer.
 
 [![E-Mail](https://img.shields.io/badge/email-hello@cloudposse.com-blue.svg)](mailto:hello@cloudposse.com)
 
@@ -144,7 +144,7 @@ We provide [*commercial support*][commercial_support] for all of our [Open Sourc
 - **Bug Fixes.** We'll rapidly work to fix any bugs in our projects.
 - **Build New Terraform Modules.** We'll develop original modules to provision infrastructure.
 - **Cloud Architecture.** We'll assist with your cloud strategy and design.
-- **Implementation.** We'll provide hands-on support to implement our reference architectures. 
+- **Implementation.** We'll provide hands-on support to implement our reference architectures.
 
 
 ## Community Forum
@@ -178,9 +178,9 @@ Copyright © 2017-2018 [Cloud Posse, LLC](https://cloudposse.com)
 
 
 
-## License 
+## License
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 See [LICENSE](LICENSE) for full details.
 
@@ -221,7 +221,7 @@ This project is maintained and funded by [Cloud Posse, LLC][website]. Like it? P
 
 We're a [DevOps Professional Services][hire] company based in Los Angeles, CA. We love [Open Source Software](https://github.com/cloudposse/)!
 
-We offer paid support on all of our projects.  
+We offer paid support on all of our projects.
 
 Check out [our other projects][github], [apply for a job][jobs], or [hire us][hire] to help with your cloud strategy and implementation.
 

--- a/alarms.tf
+++ b/alarms.tf
@@ -3,7 +3,7 @@ data "aws_region" "current" {}
 
 locals {
   alert_for     = "CloudTrailBreach"
-  sns_topic_arn = "${var.sns_topic_arn == "" ? aws_sns_topic.default.arn : var.sns_topic_arn }"
+  sns_topic_arn = "${var.sns_topic_arn == "" ? aws_sns_topic.default.arn : var.sns_topic_arn}"
   endpoints     = "${distinct(compact(concat(list(local.sns_topic_arn), var.additional_endpoint_arns)))}"
   region        = "${var.region == "" ? data.aws_region.current.name : var.region}"
 
@@ -88,10 +88,10 @@ resource "aws_cloudwatch_metric_alarm" "default" {
   evaluation_periods  = "1"
   metric_name         = "${local.metric_name[count.index]}"
   namespace           = "${local.metric_namespace}"
-  period              = "300"                                                                         // 5 min
+  period              = "300" // 5 min
   statistic           = "Sum"
   treat_missing_data  = "notBreaching"
-  threshold           = "${local.metric_name[count.index] == "ConsoleSignInFailureCount" ? "3" :"1"}"
+  threshold           = "${local.metric_name[count.index] == "ConsoleSignInFailureCount" ? "3" : "1"}"
   alarm_description   = "${local.alarm_description[count.index]}"
   alarm_actions       = ["${local.endpoints}"]
 }
@@ -111,7 +111,7 @@ resource "aws_cloudwatch_dashboard" "main" {
           "height":16,
           "properties":{
              "metrics":[
-               ${join(",",formatlist("[ \"${local.metric_namespace}\", \"%v\" ]", local.metric_name))}
+               ${join(",", formatlist("[ \"${local.metric_namespace}\", \"%v\" ]", local.metric_name))}
              ],
              "period":300,
              "stat":"Sum",
@@ -128,29 +128,55 @@ resource "aws_cloudwatch_dashboard" "main_individual" {
   count          = "${var.create_dashboard == "true" ? 1 : 0}"
   dashboard_name = "CISBenchmark_Statistics_Individual"
 
+  #   dashboard_body = <<EOF
+  #  {
+  #    "widgets": [
+  #      ${join(",",formatlist(
+  #        "{
+  #           \"type\":\"metric\",
+  #           \"x\":%v,
+  #           \"y\":%v,
+  #           \"width\":12,
+  #           \"height\":6,
+  #           \"properties\":{
+  #              \"metrics\":[
+  #                 [ \"${local.metric_namespace}\", \"%v\" ]
+  #             ],
+  #           \"period\":300,
+  #           \"stat\":\"Sum\",
+  #           \"region\":\"${var.region}\",
+  #           \"title\":\"%v\"
+  #           }
+  #        }", local.layout_x, local.layout_y, local.metric_name, local.metric_name))}
+  #    ]
+  #  }
+  #  EOF
+
   dashboard_body = <<EOF
- {
-   "widgets": [
-     ${join(",",formatlist(
-       "{
-          \"type\":\"metric\",
-          \"x\":%v,
-          \"y\":%v,
-          \"width\":12,
-          \"height\":6,
-          \"properties\":{
-             \"metrics\":[
-                [ \"${local.metric_namespace}\", \"%v\" ]
-            ],
-          \"period\":300,
-          \"stat\":\"Sum\",
-          \"region\":\"${var.region}\",
-          \"title\":\"%v\"
+  {
+    "widgets":[
+      ${join(",", formatlist(<<-EOT
+          {
+            "type": "metric",
+            "x": %v,
+            "y": %v,
+            "width": 12,
+            "height": 6,
+            "properties": {
+              "metrics": [
+                ["${local.metric_namespace}", "%v"]
+              ],
+            "period": 300,
+            "stat": "Sum",
+            "region": "${var.region}",
+            "title": "%v"
+            }
           }
-       }
-       ", local.layout_x, local.layout_y, local.metric_name, local.metric_name))}
-   ]
- }
+        EOT
+, local.layout_x, local.layout_y, local.metric_name, local.metric_name))
+}
+    ]
+  }
  EOF
 }
 

--- a/alarms.tf
+++ b/alarms.tf
@@ -3,9 +3,9 @@ data "aws_region" "current" {}
 
 locals {
   alert_for     = "CloudTrailBreach"
-  sns_topic_arn = "${var.sns_topic_arn == "" ? aws_sns_topic.default.arn : var.sns_topic_arn}"
-  endpoints     = "${distinct(compact(concat(list(local.sns_topic_arn), var.additional_endpoint_arns)))}"
-  region        = "${var.region == "" ? data.aws_region.current.name : var.region}"
+  sns_topic_arn = var.sns_topic_arn == null ? aws_sns_topic.default.arn : var.sns_topic_arn
+  endpoints     = distinct(compact(concat(list(local.sns_topic_arn), var.additional_endpoint_arns)))
+  region        = var.region == null ? data.aws_region.current.name : var.region
 
   metric_name = [
     "AuthorizationFailureCount",
@@ -26,7 +26,7 @@ locals {
     "RouteTableChangesCount",
   ]
 
-  metric_namespace = "${var.metric_namespace}"
+  metric_namespace = var.metric_namespace
   metric_value     = "1"
 
   filter_pattern = [
@@ -69,35 +69,35 @@ locals {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "default" {
-  count          = "${length(local.filter_pattern)}"
+  count          = length(local.filter_pattern)
   name           = "${local.metric_name[count.index]}-filter"
-  pattern        = "${local.filter_pattern[count.index]}"
-  log_group_name = "${var.log_group_name}"
+  pattern        = local.filter_pattern[count.index]
+  log_group_name = var.log_group_name
 
   metric_transformation {
-    name      = "${local.metric_name[count.index]}"
-    namespace = "${local.metric_namespace}"
-    value     = "${local.metric_value}"
+    name      = local.metric_name[count.index]
+    namespace = local.metric_namespace
+    value     = local.metric_value
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "default" {
-  count               = "${length(local.filter_pattern)}"
+  count               = length(local.filter_pattern)
   alarm_name          = "${local.metric_name[count.index]}-alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
-  metric_name         = "${local.metric_name[count.index]}"
-  namespace           = "${local.metric_namespace}"
+  metric_name         = local.metric_name[count.index]
+  namespace           = local.metric_namespace
   period              = "300" // 5 min
   statistic           = "Sum"
   treat_missing_data  = "notBreaching"
   threshold           = "${local.metric_name[count.index] == "ConsoleSignInFailureCount" ? "3" : "1"}"
-  alarm_description   = "${local.alarm_description[count.index]}"
-  alarm_actions       = ["${local.endpoints}"]
+  alarm_description   = local.alarm_description[count.index]
+  alarm_actions       = local.endpoints
 }
 
 resource "aws_cloudwatch_dashboard" "main" {
-  count          = "${var.create_dashboard == "true" ? 1 : 0}"
+  count          = var.create_dashboard == true ? 1 : 0
   dashboard_name = "CISBenchmark_Statistics_Combined"
 
   dashboard_body = <<EOF
@@ -115,7 +115,7 @@ resource "aws_cloudwatch_dashboard" "main" {
              ],
              "period":300,
              "stat":"Sum",
-             "region":"${var.region}",
+             "region":"${local.region}",
              "title":"CISBenchmark Statistics"
           }
        }
@@ -125,32 +125,8 @@ resource "aws_cloudwatch_dashboard" "main" {
 }
 
 resource "aws_cloudwatch_dashboard" "main_individual" {
-  count          = "${var.create_dashboard == "true" ? 1 : 0}"
+  count          = var.create_dashboard == true ? 1 : 0
   dashboard_name = "CISBenchmark_Statistics_Individual"
-
-  #   dashboard_body = <<EOF
-  #  {
-  #    "widgets": [
-  #      ${join(",",formatlist(
-  #        "{
-  #           \"type\":\"metric\",
-  #           \"x\":%v,
-  #           \"y\":%v,
-  #           \"width\":12,
-  #           \"height\":6,
-  #           \"properties\":{
-  #              \"metrics\":[
-  #                 [ \"${local.metric_namespace}\", \"%v\" ]
-  #             ],
-  #           \"period\":300,
-  #           \"stat\":\"Sum\",
-  #           \"region\":\"${var.region}\",
-  #           \"title\":\"%v\"
-  #           }
-  #        }", local.layout_x, local.layout_y, local.metric_name, local.metric_name))}
-  #    ]
-  #  }
-  #  EOF
 
   dashboard_body = <<EOF
   {
@@ -168,7 +144,7 @@ resource "aws_cloudwatch_dashboard" "main_individual" {
               ],
             "period": 300,
             "stat": "Sum",
-            "region": "${var.region}",
+            "region": "${local.region}",
             "title": "%v"
             }
           }

--- a/alarms.tf
+++ b/alarms.tf
@@ -91,7 +91,7 @@ resource "aws_cloudwatch_metric_alarm" "default" {
   period              = "300" // 5 min
   statistic           = "Sum"
   treat_missing_data  = "notBreaching"
-  threshold           = "${local.metric_name[count.index] == "ConsoleSignInFailureCount" ? "3" : "1"}"
+  threshold           = local.metric_name[count.index] == "ConsoleSignInFailureCount" ? "3" : "1"
   alarm_description   = local.alarm_description[count.index]
   alarm_actions       = local.endpoints
 }

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,3 @@
-# ----------------------------------------------------------------------------------------------------------------------
-# REQUIRE A SPECIFIC TERRAFORM VERSION OR HIGHER
-# This module has been updated with 0.12 syntax, which means it is no longer compatible with any versions below 0.12.
-# ----------------------------------------------------------------------------------------------------------------------
-terraform {
-  required_version = ">= 0.12"
-}
-
 data "aws_caller_identity" "default" {}
 
 # Make a topic

--- a/main.tf
+++ b/main.tf
@@ -6,9 +6,9 @@ resource "aws_sns_topic" "default" {
 }
 
 resource "aws_sns_topic_policy" "default" {
-  count  = "${var.add_sns_policy != "true" && var.sns_topic_arn != "" ? 0 : 1}"
-  arn    = "${local.sns_topic_arn}"
-  policy = "${data.aws_iam_policy_document.sns_topic_policy.json}"
+  count  = var.add_sns_policy != true && var.sns_topic_arn != null ? 0 : 1
+  arn    = local.sns_topic_arn
+  policy = data.aws_iam_policy_document.sns_topic_policy.json
 }
 
 data "aws_iam_policy_document" "sns_topic_policy" {
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
     ]
 
     effect    = "Allow"
-    resources = ["${local.sns_topic_arn}"]
+    resources = [local.sns_topic_arn]
 
     principals {
       type        = "AWS"
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
   statement {
     sid       = "Allow ${local.alert_for} CloudwatchEvents"
     actions   = ["sns:Publish"]
-    resources = ["${local.sns_topic_arn}"]
+    resources = [local.sns_topic_arn]
 
     principals {
       type        = "Service"

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,11 @@
+# ----------------------------------------------------------------------------------------------------------------------
+# REQUIRE A SPECIFIC TERRAFORM VERSION OR HIGHER
+# This module has been updated with 0.12 syntax, which means it is no longer compatible with any versions below 0.12.
+# ----------------------------------------------------------------------------------------------------------------------
+terraform {
+  required_version = ">= 0.12"
+}
+
 data "aws_caller_identity" "default" {}
 
 # Make a topic

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,10 +5,10 @@ output "sns_topic_arn" {
 
 output "dashboard_combined" {
   description = "URL to CloudWatch Combined Metric Dashboard"
-  value       = "https://console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=${join("",aws_cloudwatch_dashboard.main.*.dashboard_name)}"
+  value       = "https://console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=${join("", aws_cloudwatch_dashboard.main.*.dashboard_name)}"
 }
 
 output "dashboard_individual" {
   description = "URL to CloudWatch Individual Metric Dashboard"
-  value       = "https://console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=${join("",aws_cloudwatch_dashboard.main_individual.*.dashboard_name)}"
+  value       = "https://console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=${join("", aws_cloudwatch_dashboard.main_individual.*.dashboard_name)}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,14 +1,14 @@
 output "sns_topic_arn" {
   description = "The ARN of the SNS topic used"
-  value       = "${local.sns_topic_arn}"
+  value       = local.sns_topic_arn
 }
 
 output "dashboard_combined" {
   description = "URL to CloudWatch Combined Metric Dashboard"
-  value       = "https://console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=${join("", aws_cloudwatch_dashboard.main.*.dashboard_name)}"
+  value       = "https://console.aws.amazon.com/cloudwatch/home?region=${local.region}#dashboards:name=${join("", aws_cloudwatch_dashboard.main.*.dashboard_name)}"
 }
 
 output "dashboard_individual" {
   description = "URL to CloudWatch Individual Metric Dashboard"
-  value       = "https://console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=${join("", aws_cloudwatch_dashboard.main_individual.*.dashboard_name)}"
+  value       = "https://console.aws.amazon.com/cloudwatch/home?region=${local.region}#dashboards:name=${join("", aws_cloudwatch_dashboard.main_individual.*.dashboard_name)}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,37 +1,40 @@
 variable "additional_endpoint_arns" {
   description = "Any alert endpoints, such as autoscaling, or app scaling endpoint arns that will respond to an alert"
   default     = []
-  type        = "list"
+  type        = list(string)
 }
 
 variable "sns_topic_arn" {
   description = "An SNS topic ARN that has already been created. Its policy must already allow access from CloudWatch Alarms, or set `add_sns_policy` to `true`"
-  default     = ""
-  type        = "string"
+  default     = null
+  type        = string
 }
 
 variable "add_sns_policy" {
   description = "Attach a policy that allows the notifications through to the SNS topic endpoint"
-  default     = "false"
-  type        = "string"
+  default     = false
+  type        = string
 }
 
 variable "region" {
   description = "The region that should be monitored for unauthorised AWS API Access. Current region used if none provied."
-  default     = ""
-  type        = "string"
+  default     = null
+  type        = string
 }
 
 variable "log_group_name" {
   description = "The cloudtrail cloudwatch log group name"
+  type        = string
 }
 
 variable "metric_namespace" {
   description = "A namespace for grouping all of the metrics together"
   default     = "CISBenchmark"
+  type        = string
 }
 
 variable "create_dashboard" {
   description = "When true a dashboard that displays the statistics as a line graph will be created in CloudWatch"
-  default     = "true"
+  default     = true
+  type        = bool
 }

--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,7 @@ variable "sns_topic_arn" {
 variable "add_sns_policy" {
   description = "Attach a policy that allows the notifications through to the SNS topic endpoint"
   default     = false
-  type        = string
+  type        = bool
 }
 
 variable "region" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = "~> 0.12.0"
+}


### PR DESCRIPTION
- Refactor `dashboard_body` to use heredoc syntax instead of multiline string
- Fix `var.region` errors in outputs and dashboard declarations
- Fix spelling errors in `README.md`
- Add Terraform `required_version` block to ensure 0.12 or greater syntax is being used
