### PR TITLE
Move widget format to local

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -5,10 +5,10 @@ output "sns_topic_arn" {
 
 output "dashboard_combined" {
   description = "URL to CloudWatch Combined Metric Dashboard"
-  value       = "https://console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=${join("",aws_cloudwatch_dashboard.main.*.dashboard_name)}"
+  value       = "https://console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=${join("", aws_cloudwatch_dashboard.main.*.dashboard_name)}"
 }
 
 output "dashboard_individual" {
   description = "URL to CloudWatch Individual Metric Dashboard"
-  value       = "https://console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=${join("",aws_cloudwatch_dashboard.main_individual.*.dashboard_name)}"
+  value       = "https://console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=${join("", aws_cloudwatch_dashboard.main_individual.*.dashboard_name)}"
 }


### PR DESCRIPTION
## Problem
Individual cloudwatch dashboard widgets seem to be failing with Terraform 0.12 based on how formatlist and multiline strings work.

## Solution
Moved format for widget object into it's own local for reference by formatlist

Fixes #11 