### PR TITLE
Update for Terraform 0.12.20 and AWS provider 2.49.0

### DIFF
--- a/alarms.tf
+++ b/alarms.tf
@@ -1,11 +1,16 @@
-data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
+data "aws_caller_identity" "current" {
+}
+
+data "aws_region" "current" {
+}
 
 locals {
   alert_for     = "CloudTrailBreach"
-  sns_topic_arn = "${var.sns_topic_arn == "" ? aws_sns_topic.default.arn : var.sns_topic_arn }"
-  endpoints     = "${distinct(compact(concat(list(local.sns_topic_arn), var.additional_endpoint_arns)))}"
-  region        = "${var.region == "" ? data.aws_region.current.name : var.region}"
+  sns_topic_arn = var.sns_topic_arn == "" ? aws_sns_topic.default.arn : var.sns_topic_arn
+  endpoints     = distinct(
+    compact(concat([local.sns_topic_arn], var.additional_endpoint_arns)),
+  )
+  region = var.region == "" ? data.aws_region.current.name : var.region
 
   metric_name = [
     "AuthorizationFailureCount",
@@ -26,7 +31,7 @@ locals {
     "RouteTableChangesCount",
   ]
 
-  metric_namespace = "${var.metric_namespace}"
+  metric_namespace = var.metric_namespace
   metric_value     = "1"
 
   filter_pattern = [
@@ -69,35 +74,35 @@ locals {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "default" {
-  count          = "${length(local.filter_pattern)}"
+  count          = length(local.filter_pattern)
   name           = "${local.metric_name[count.index]}-filter"
-  pattern        = "${local.filter_pattern[count.index]}"
-  log_group_name = "${var.log_group_name}"
+  pattern        = local.filter_pattern[count.index]
+  log_group_name = var.log_group_name
 
   metric_transformation {
-    name      = "${local.metric_name[count.index]}"
-    namespace = "${local.metric_namespace}"
-    value     = "${local.metric_value}"
+    name      = local.metric_name[count.index]
+    namespace = local.metric_namespace
+    value     = local.metric_value
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "default" {
-  count               = "${length(local.filter_pattern)}"
+  count               = length(local.filter_pattern)
   alarm_name          = "${local.metric_name[count.index]}-alarm"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"
-  metric_name         = "${local.metric_name[count.index]}"
-  namespace           = "${local.metric_namespace}"
-  period              = "300"                                                                         // 5 min
+  metric_name         = local.metric_name[count.index]
+  namespace           = local.metric_namespace
+  period              = "300" // 5 min
   statistic           = "Sum"
   treat_missing_data  = "notBreaching"
-  threshold           = "${local.metric_name[count.index] == "ConsoleSignInFailureCount" ? "3" :"1"}"
-  alarm_description   = "${local.alarm_description[count.index]}"
-  alarm_actions       = ["${local.endpoints}"]
+  threshold           = local.metric_name[count.index] == "ConsoleSignInFailureCount" ? "3" : "1"
+  alarm_description   = local.alarm_description[count.index]
+  alarm_actions       = local.endpoints
 }
 
 resource "aws_cloudwatch_dashboard" "main" {
-  count          = "${var.create_dashboard == "true" ? 1 : 0}"
+  count          = var.create_dashboard == "true" ? 1 : 0
   dashboard_name = "CISBenchmark_Statistics_Combined"
 
   dashboard_body = <<EOF
@@ -111,7 +116,13 @@ resource "aws_cloudwatch_dashboard" "main" {
           "height":16,
           "properties":{
              "metrics":[
-               ${join(",",formatlist("[ \"${local.metric_namespace}\", \"%v\" ]", local.metric_name))}
+               ${join(
+  ",",
+  formatlist(
+    "[ \"${local.metric_namespace}\", \"%v\" ]",
+    local.metric_name,
+  ),
+)}
              ],
              "period":300,
              "stat":"Sum",
@@ -121,43 +132,39 @@ resource "aws_cloudwatch_dashboard" "main" {
        }
    ]
  }
- EOF
+ 
+EOF
+
 }
 
 resource "aws_cloudwatch_dashboard" "main_individual" {
-  count          = "${var.create_dashboard == "true" ? 1 : 0}"
+  count          = var.create_dashboard == "true" ? 1 : 0
   dashboard_name = "CISBenchmark_Statistics_Individual"
 
   dashboard_body = <<EOF
  {
    "widgets": [
-     ${join(",",formatlist(
-       "{
-          \"type\":\"metric\",
-          \"x\":%v,
-          \"y\":%v,
-          \"width\":12,
-          \"height\":6,
-          \"properties\":{
-             \"metrics\":[
-                [ \"${local.metric_namespace}\", \"%v\" ]
-            ],
-          \"period\":300,
-          \"stat\":\"Sum\",
-          \"region\":\"${var.region}\",
-          \"title\":\"%v\"
-          }
-       }
-       ", local.layout_x, local.layout_y, local.metric_name, local.metric_name))}
+     ${join(
+  ",",
+  formatlist(
+    "{\n          \"type\":\"metric\",\n          \"x\":%v,\n          \"y\":%v,\n          \"width\":12,\n          \"height\":6,\n          \"properties\":{\n             \"metrics\":[\n                [ \"${local.metric_namespace}\", \"%v\" ]\n            ],\n          \"period\":300,\n          \"stat\":\"Sum\",\n          \"region\":\"${var.region}\",\n          \"title\":\"%v\"\n          }\n       }\n       ",
+    local.layout_x,
+    local.layout_y,
+    local.metric_name,
+    local.metric_name,
+  ),
+)}
    ]
  }
- EOF
+ 
+EOF
+
 }
 
 locals {
   # Two Columns
-  # Will experiment with this values
   layout_x = [0, 12, 0, 12, 0, 12, 0, 12, 0, 12, 0, 12, 0, 12, 0, 12]
 
   layout_y = [0, 0, 7, 7, 15, 15, 22, 22, 29, 29, 36, 36, 43, 43, 50, 50]
 }
+

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,12 +1,12 @@
 ### For connecting and provisioning
 variable "region" {
-  default = "us-east-1"
+  default = "us-west-2"
 }
 
 data "aws_caller_identity" "current" {}
 
 provider "aws" {
-  region = "${var.region}"
+  region = var.region
 
   # Make it faster by skipping something
   skip_get_ec2_platforms      = true
@@ -22,8 +22,8 @@ module "cloudtrail_api_alarms" {
   # source         = "git::https://github.com/cloudposse/terraform-aws-cloudtrail-cloudwatch-alarms.git?ref=master"
   source = "../../"
 
-  region         = "${var.region}"
-  log_group_name = "${aws_cloudwatch_log_group.default.name}"
+  region         = var.region
+  log_group_name = aws_cloudwatch_log_group.default.name
 }
 
 ## Everything after this is standard cloudtrail setup
@@ -32,13 +32,13 @@ module "cloudtrail_api_alarms" {
 ## Copy the contents of the bucket somewhere first.
 resource "aws_s3_bucket" "default" {
   bucket_prefix = "cw-bucket-${var.region}"
-  region        = "${var.region}"
+  region        = var.region
 
   force_destroy = true
 }
 
 resource "aws_s3_bucket_policy" "default" {
-  bucket = "${aws_s3_bucket.default.id}"
+  bucket = aws_s3_bucket.default.id
 
   policy = <<EOF
 {
@@ -66,29 +66,27 @@ EOF
 
 resource "aws_iam_role" "cloudtrail_cloudwatch_events_role" {
   name_prefix        = "cloudtrail_events_role"
-  assume_role_policy = "${data.aws_iam_policy_document.assume_policy.json}"
+  assume_role_policy = data.aws_iam_policy_document.assume_policy.json
 }
 
 resource "aws_iam_role_policy" "policy" {
   name_prefix = "cloudtrail_cloudwatch_events_policy"
-  role        = "${aws_iam_role.cloudtrail_cloudwatch_events_role.id}"
-  policy      = "${data.aws_iam_policy_document.policy.json}"
+  role        = aws_iam_role.cloudtrail_cloudwatch_events_role.id
+  policy      = data.aws_iam_policy_document.policy.json
 }
 
 data "aws_iam_policy_document" "policy" {
   statement {
-    effect  = "Allow"
-    actions = ["logs:CreateLogStream"]
-
+    effect    = "Allow"
+    actions   = ["logs:CreateLogStream"]
     resources = [
       "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:${aws_cloudwatch_log_group.default.name}:log-stream:*",
     ]
   }
 
   statement {
-    effect  = "Allow"
-    actions = ["logs:PutLogEvents"]
-
+    effect    = "Allow"
+    actions   = ["logs:PutLogEvents"]
     resources = [
       "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:${aws_cloudwatch_log_group.default.name}:log-stream:*",
     ]
@@ -99,8 +97,7 @@ data "aws_iam_policy_document" "assume_policy" {
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
-
-    principals = {
+    principals {
       type        = "Service"
       identifiers = ["cloudtrail.amazonaws.com"]
     }
@@ -114,13 +111,13 @@ resource "aws_cloudwatch_log_group" "default" {
 resource "aws_cloudtrail" "default" {
   name                          = "cloudtrail-${var.region}"
   enable_logging                = "true"
-  s3_bucket_name                = "${aws_s3_bucket.default.id}"
+  s3_bucket_name                = aws_s3_bucket.default.id
   enable_log_file_validation    = "false"
   is_multi_region_trail         = "true"
   include_global_service_events = "true"
-  cloud_watch_logs_role_arn     = "${aws_iam_role.cloudtrail_cloudwatch_events_role.arn}"
-  cloud_watch_logs_group_arn    = "${aws_cloudwatch_log_group.default.arn}"
-  depends_on                    = ["aws_s3_bucket_policy.default", "aws_iam_role_policy.policy"]
+  cloud_watch_logs_role_arn     = aws_iam_role.cloudtrail_cloudwatch_events_role.arn
+  cloud_watch_logs_group_arn    = aws_cloudwatch_log_group.default.arn
+  depends_on                    = [aws_s3_bucket_policy.default, aws_iam_role_policy.policy]
 
   # provisioner "local-exec" {
   #   command = "sleep 10"

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,5 @@
-data "aws_caller_identity" "default" {}
+data "aws_caller_identity" "default" {
+}
 
 # Make a topic
 resource "aws_sns_topic" "default" {
@@ -6,9 +7,9 @@ resource "aws_sns_topic" "default" {
 }
 
 resource "aws_sns_topic_policy" "default" {
-  count  = "${var.add_sns_policy != "true" && var.sns_topic_arn != "" ? 0 : 1}"
-  arn    = "${local.sns_topic_arn}"
-  policy = "${data.aws_iam_policy_document.sns_topic_policy.json}"
+  count  = var.add_sns_policy != "true" && var.sns_topic_arn != "" ? 0 : 1
+  arn    = local.sns_topic_arn
+  policy = data.aws_iam_policy_document.sns_topic_policy.json
 }
 
 data "aws_iam_policy_document" "sns_topic_policy" {
@@ -30,7 +31,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
     ]
 
     effect    = "Allow"
-    resources = ["${local.sns_topic_arn}"]
+    resources = [local.sns_topic_arn]
 
     principals {
       type        = "AWS"
@@ -40,8 +41,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
     condition {
       test     = "StringEquals"
       variable = "AWS:SourceOwner"
-
-      values = [
+      values   = [
         "arn:aws:iam::${data.aws_caller_identity.default.account_id}:root",
       ]
     }
@@ -50,7 +50,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
   statement {
     sid       = "Allow ${local.alert_for} CloudwatchEvents"
     actions   = ["sns:Publish"]
-    resources = ["${local.sns_topic_arn}"]
+    resources = [local.sns_topic_arn]
 
     principals {
       type        = "AWS"
@@ -60,7 +60,8 @@ data "aws_iam_policy_document" "sns_topic_policy" {
     condition {
       test     = "StringEquals"
       variable = "AWS:SourceArn"
-      values   = ["${aws_cloudwatch_metric_alarm.default.*.arn}"]
+      values   = aws_cloudwatch_metric_alarm.default.*.arn
     }
   }
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,14 +1,18 @@
 output "sns_topic_arn" {
   description = "The ARN of the SNS topic used"
-  value       = "${local.sns_topic_arn}"
+  value       = local.sns_topic_arn
 }
 
 output "dashboard_combined" {
   description = "URL to CloudWatch Combined Metric Dashboard"
-  value       = "https://console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=${join("",aws_cloudwatch_dashboard.main.*.dashboard_name)}"
+  value       = "https://console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=${join("", aws_cloudwatch_dashboard.main.*.dashboard_name)}"
 }
 
 output "dashboard_individual" {
   description = "URL to CloudWatch Individual Metric Dashboard"
-  value       = "https://console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=${join("",aws_cloudwatch_dashboard.main_individual.*.dashboard_name)}"
+  value       = "https://console.aws.amazon.com/cloudwatch/home?region=${var.region}#dashboards:name=${join(
+    "",
+    aws_cloudwatch_dashboard.main_individual.*.dashboard_name,
+  )}"
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,25 +1,25 @@
 variable "additional_endpoint_arns" {
   description = "Any alert endpoints, such as autoscaling, or app scaling endpoint arns that will respond to an alert"
   default     = []
-  type        = "list"
+  type        = list(string)
 }
 
 variable "sns_topic_arn" {
   description = "An SNS topic ARN that has already been created. Its policy must already allow access from CloudWatch Alarms, or set `add_sns_policy` to `true`"
   default     = ""
-  type        = "string"
+  type        = string
 }
 
 variable "add_sns_policy" {
   description = "Attach a policy that allows the notifications through to the SNS topic endpoint"
   default     = "false"
-  type        = "string"
+  type        = string
 }
 
 variable "region" {
   description = "The region that should be monitored for unauthorised AWS API Access. Current region used if none provied."
   default     = ""
-  type        = "string"
+  type        = string
 }
 
 variable "log_group_name" {
@@ -35,3 +35,4 @@ variable "create_dashboard" {
   description = "When true a dashboard that displays the statistics as a line graph will be created in CloudWatch"
   default     = "true"
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,6 @@
+terraform {
+  required_version = ">= 0.12.20"
+    required_providers {
+      aws = ">=2.49.0"
+  }
+}


### PR DESCRIPTION
Update for Terraform 0.12.20 and AWS provider 2.49.0

`terraform validate` complains about the dashboard body indentation if it's made "pretty", so I've kept the unsightly but valid changes from `terraform 0.12upgrade`.