### PR TITLE
Feature/alarm suffix

### DIFF
--- a/alarms.tf
+++ b/alarms.tf
@@ -16,6 +16,7 @@ locals {
 resource "aws_cloudwatch_log_metric_filter" "default" {
   for_each       = module.this.enabled ? var.metrics : {}
   name           = each.value.metric_name
+  metric_name    = var.alarm_suffix != null ? join("-", tolist([each.value.metric_name, var.alarm_suffix])) : each.value.metric_name
   pattern        = each.value.filter_pattern
   log_group_name = var.log_group_name
 

--- a/variables.tf
+++ b/variables.tf
@@ -66,6 +66,6 @@ variable "metrics" {
 
 variable "alarm_suffix" {
   type        = string
-  description = "Alarm name suffix. Set to `null` to avoid adding a suffix.
+  description = "Alarm name suffix. Set to `null` to avoid adding a suffix."
   default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -63,3 +63,9 @@ variable "metrics" {
   default     = {}
   description = "The cloudwatch metrics and corresponding alarm definitions"
 }
+
+variable "alarm_suffix" {
+  type        = string
+  description = "Alarm name suffix. Set to `null` to avoid adding a suffix.
+  default     = null
+}


### PR DESCRIPTION
## what
* Add alarm name suffix support

## why
* To be able differenciate alarms among environment, accounts, etc.
